### PR TITLE
remove cap

### DIFF
--- a/scripts/setup_mongo.js
+++ b/scripts/setup_mongo.js
@@ -12,9 +12,6 @@ db.users.createIndex({email: 1}, {unique: true})
 // Disallow duplicate usernames
 db.users.createIndex({username: 1}, {unique: true})
 
-// staged_users capped collection
-db.createCollection('staged_users', {capped: true, size: 5120000, max: 5000})
-
 // Disallow duplicate staged emails
 db.staged_users.createIndex({email: 1}, {unique: true})
 


### PR DESCRIPTION
can't delete from capped collections :(

i'm thinking we just allow disk to fill up for now. we won't have any billing risk since it's capped by the ec2 disk size. so the only risk is availability.
