### PR TITLE
remove double encoding

### DIFF
--- a/src/konu_notes/handler.clj
+++ b/src/konu_notes/handler.clj
@@ -164,7 +164,7 @@
                               :password (:password data)})))
 
   (POST "/redeem-signup" {data :params}
-        (json (signup/redeem-signup data)))
+    (signup/redeem-signup data))
 
   ; Account creation with user-level privilege.
   (POST "/user" {data :params}

--- a/src/konu_notes/handler.clj
+++ b/src/konu_notes/handler.clj
@@ -223,6 +223,6 @@
    (middleware/wrap-json-body {:keywords? true :bigdecimals? true})
    middleware/wrap-json-params
    ;; Allow origin.
-   (wrap-cors :access-control-allow-origin #"http://localhost:8888"
+   (wrap-cors :access-control-allow-origin #"http://localhost:8888|https://konu.io"
               :access-control-allow-methods [:get :put :post :delete])))
 


### PR DESCRIPTION
tiny fix to remove double encoded json response.

before fix, we are getting the following as the body:

```
{"status":200,"body":"{\"token\":\"123\"}"}
```

after fix, we get the following as the body:

```
{"token":"123"}
```

[edit] also, add origin for konu.io.
